### PR TITLE
Fix output file path when generating data_model.json/.bin

### DIFF
--- a/tools/dependencies/esp-matter/tools/matter_data_model_interpreter/main.py
+++ b/tools/dependencies/esp-matter/tools/matter_data_model_interpreter/main.py
@@ -46,18 +46,19 @@ def ensure_attribute_files():
         raise FileNotFoundError("Failed to create attribute_bounds.csv or attribute_bounds.pkl")
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: python main.py <path_to_.matter_file>")
+    if len(sys.argv) < 3:
+        print("Usage: python main.py <path_to_.matter_file> <output_files_path>")
         sys.exit(1)
 
     idl_file_path = sys.argv[1]
+    output_files_path = sys.argv[2]
 
     if not os.path.exists(idl_file_path):
         print(f"File not found: {idl_file_path}")
         sys.exit(1)
 
-    if not os.path.exists("out"):
-        os.makedirs("out")
+    if not os.path.exists(output_files_path):
+        os.makedirs(output_files_path)
 
     ensure_attribute_files()
 
@@ -65,11 +66,11 @@ def main():
     run_linter(idl_file_path)
 
     # Create JSON data model
-    json_file_path = os.path.join("out", "data_model.json")
+    json_file_path = os.path.join(output_files_path, "data_model.json")
     create_json_data_model(idl_file_path, json_file_path)
 
     # Create binary file from JSON data model
-    bin_file_path = os.path.join("out", "data_model.bin")
+    bin_file_path = os.path.join(output_files_path, "data_model.bin")
     create_binary_file(json_file_path, bin_file_path)
 
 if __name__ == "__main__":

--- a/tools/mfg/mfg_low_code.sh
+++ b/tools/mfg/mfg_low_code.sh
@@ -75,7 +75,7 @@ echo "Using .matter file: $matter_file"
 
 # Call main.py from matter_data_model_interpreter
 cd "$ESP_MATTER_PATH/tools/matter_data_model_interpreter"
-python3 main.py "$matter_file"
+python3 main.py "$matter_file" "$product_folder/configuration/output/$mac_address"
 
 # Check if the script executed successfully
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Description

Fix output file path when generating data_model.json/.bin.

## Related

Fixes #7 

## Testing

I have tested building the light example after deleting data_model.bin in configuration. All is working as expected, matter device well commissioned and responding.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ x] 🚨 This PR does not introduce breaking changes.
- [ x] All CI checks (GH Actions) pass.
- [ x] Documentation is updated as needed.
- [ x] Tests are updated or added as necessary.
- [ x] Code is well-commented, especially in complex areas.
- [ x] Git history is clean — commits are squashed to the minimum necessary.
